### PR TITLE
Bugfix/Workaround for heapq.heappush(item) for item being uncomparable

### DIFF
--- a/map_matching/shortest_path.py
+++ b/map_matching/shortest_path.py
@@ -1,6 +1,10 @@
 import heapq
 import collections
 
+# heapq.heappush workaround by https://stackoverflow.com/a/39504878
+from itertools import count
+tiebreaker = count()
+
 
 Edge = collections.namedtuple('Edge', ['start_node', 'end_node', 'cost'])
 
@@ -21,7 +25,7 @@ def _pop_unscanned_edge(pqueue, scanned_nodes):
     """
     assert pqueue
     while True:
-        cost_sofar, edge = heapq.heappop(pqueue)
+        cost_sofar, _, edge = heapq.heappop(pqueue)
         if not pqueue or edge.end_node not in scanned_nodes:
             break
     if edge.end_node in scanned_nodes:
@@ -74,7 +78,7 @@ def find_shortest_path(source_node, target_node, get_edges, max_path_cost=None):
         max_path_cost = float('inf')
     if 0 <= max_path_cost:
         # Start with a dummy edge
-        heapq.heappush(pqueue, (0, Edge(None, source_node, 0)))
+        heapq.heappush(pqueue, (0, next(tiebreaker), Edge(None, source_node, 0)))
 
     while pqueue:
         cost_sofar, edge = _pop_unscanned_edge(pqueue, scanned_nodes)
@@ -88,7 +92,7 @@ def find_shortest_path(source_node, target_node, get_edges, max_path_cost=None):
             assert adj_edge.start_node == cur_node
             adj_cost_sofar = cost_sofar + adj_edge.cost
             if adj_cost_sofar <= max_path_cost and adj_edge.end_node not in scanned_nodes:
-                heapq.heappush(pqueue, (adj_cost_sofar, adj_edge))
+                heapq.heappush(pqueue, (adj_cost_sofar, next(tiebreaker), adj_edge))
 
     raise PathNotFound(source_node, target_node, max_path_cost)
 
@@ -112,7 +116,7 @@ def find_many_shortest_paths(source_node, target_nodes, get_edges, max_path_cost
         max_path_cost = float('inf')
     if 0 <= max_path_cost:
         # Start with a dummy edge
-        heapq.heappush(pqueue, (0, Edge(None, source_node, 0)))
+        heapq.heappush(pqueue, (0, next(tiebreaker), Edge(None, source_node, 0)))
 
     while pqueue:
         cost_sofar, edge = _pop_unscanned_edge(pqueue, scanned_nodes)
@@ -130,7 +134,7 @@ def find_many_shortest_paths(source_node, target_nodes, get_edges, max_path_cost
             assert adj_edge.start_node == cur_node
             adj_cost_sofar = cost_sofar + adj_edge.cost
             if adj_cost_sofar <= max_path_cost and adj_edge.end_node not in scanned_nodes:
-                heapq.heappush(pqueue, (adj_cost_sofar, adj_edge))
+                heapq.heappush(pqueue, (adj_cost_sofar, next(tiebreaker), adj_edge))
 
     # (None, -1) means path not found, while ([], 0) means an empty
     # path found (it happens when source and target are the same)


### PR DESCRIPTION
Currently, executing `MapMatching.offline_match` results in an error located in `shortest_path.py`:

    ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

There must have been a change in `heapq.heappush` after this code was written. The problem is that all items inserted into the heap have to be comparable. However, the `Edge` objects inserted into the heap here are implementing `__eq__` only (as opposed to `__lt__` and `__gt__`). More information about this issue can be found here: https://stackoverflow.com/a/39504878.

This PR implements a workaround taken from the above link. I validated that the map matching functions are working again using this workaround.